### PR TITLE
Delete deprecated argument

### DIFF
--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -10,6 +10,8 @@ from django.utils.html import conditional_escape, mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
+from cms.utils.compat import DJANGO_2_2
+
 from .widgets import AttributesWidget
 
 
@@ -70,6 +72,10 @@ class AttributesField(models.Field):
         self.excluded_keys = [key.lower() for key in excluded_keys]
         super().__init__(*args, **kwargs)
         self.validate(self.get_default(), None)
+        if DJANGO_2_2:
+            self.from_db_value = self._from_db_value_django_2_2_compatible
+        else:
+            self.from_db_value = self._from_db_value
 
     def formfield(self, **kwargs):
         defaults = {
@@ -79,8 +85,12 @@ class AttributesField(models.Field):
         defaults.update(**kwargs)
         return super().formfield(**defaults)
 
-    def from_db_value(self, value,
-                      expression=None, connection=None):
+    def _from_db_value_django_2_2_compatible(self, value,
+                                             expression=None, connection=None, context=None):
+        self._from_db_value(value, expression=expression, connection=connection)
+
+    def _from_db_value(self, value,
+                       expression=None, connection=None):
         """
         This is a temporary workaround for #7 taken from
         https://bitbucket.org/schinckel/django-jsonfield/pull-requests/32/make-from_db_value-compatible-with/diff

--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -10,7 +10,7 @@ from django.utils.html import conditional_escape, mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
-from cms.utils.compat import DJANGO_2_2
+from utils import DJANGO_2_2
 
 from .widgets import AttributesWidget
 

--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -80,7 +80,7 @@ class AttributesField(models.Field):
         return super().formfield(**defaults)
 
     def from_db_value(self, value,
-                      expression=None, connection=None, context=None):
+                      expression=None, connection=None):
         """
         This is a temporary workaround for #7 taken from
         https://bitbucket.org/schinckel/django-jsonfield/pull-requests/32/make-from_db_value-compatible-with/diff

--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -10,8 +10,7 @@ from django.utils.html import conditional_escape, mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 
-from utils import DJANGO_2_2
-
+from .utils import DJANGO_2_2
 from .widgets import AttributesWidget
 
 

--- a/djangocms_attributes_field/utils.py
+++ b/djangocms_attributes_field/utils.py
@@ -1,0 +1,11 @@
+from platform import python_version
+from django import get_version
+
+from distutils.version import LooseVersion
+
+
+DJANGO_VERSION = get_version()
+PYTHON_VERSION = python_version()
+
+# These means "less than or equal to DJANGO_FOO_BAR"
+DJANGO_2_2 = LooseVersion(DJANGO_VERSION) < LooseVersion('3.0')


### PR DESCRIPTION
Support for context argument was [removed](https://docs.djangoproject.com/en/3.2/releases/3.0/#:~:text=Support%20for%20the%20context%20argument%20of%20Field.from_db_value()%20and%20Expression.convert_value()%20is%20removed.) in Django 3.0 