### PR TITLE
Improve layout if djangocms-admin-style is NOT present

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+unreleased
+==========
+
+* Fix add / delete buttons if djangocms-admin-style is not installed
+
 
 2.0.0 (2020-09-02)
 ==================

--- a/djangocms_attributes_field/widgets.py
+++ b/djangocms_attributes_field/widgets.py
@@ -94,12 +94,15 @@ class AttributesWidget(Widget):
         # INSTALLED_APPS. By inlining the JS and CSS here, we avoid this.
         output += """
         <style>
-            .delete-attributes-pair,
-            .add-attributes-pair {
+            body.djangocms-admin-style .delete-attributes-pair,
+            body.djangocms-admin-style .add-attributes-pair {
                 border: 1px solid #ddd;
                 border-radius: 3px;
                 display: inline-block;
                 padding: 6px 5px 8px 10px;
+            }
+            .delete-attributes-pair, .add-attributes-pair {
+                line-height: 2;
             }
             .attributes-pair {
                 display: table;
@@ -152,6 +155,7 @@ class AttributesWidget(Widget):
                         var emptyRow = that.find('.template');
                         var btnAdd = that.find('.add-attributes-pair');
                         var btnDelete = that.find('.delete-attributes-pair');
+
 
                         btnAdd.on('click', function (event) {
                             event.preventDefault();

--- a/djangocms_attributes_field/widgets.py
+++ b/djangocms_attributes_field/widgets.py
@@ -101,7 +101,6 @@ class AttributesWidget(Widget):
                 display: inline-block;
                 padding: 6px 5px 8px 10px;
                 line-height: inherit;
-
             }
             .delete-attributes-pair, .add-attributes-pair {
                 line-height: 2;
@@ -157,7 +156,6 @@ class AttributesWidget(Widget):
                         var emptyRow = that.find('.template');
                         var btnAdd = that.find('.add-attributes-pair');
                         var btnDelete = that.find('.delete-attributes-pair');
-
 
                         btnAdd.on('click', function (event) {
                             event.preventDefault();

--- a/djangocms_attributes_field/widgets.py
+++ b/djangocms_attributes_field/widgets.py
@@ -120,7 +120,7 @@ class AttributesWidget(Widget):
             .attributes-pair .field-box:last-child {
                 display: table-cell !important;
                 vertical-align: top !important;
-                width: 100% !important;
+                width: 75% !important;
                 float: none !important;
             }
             .djangocms-attributes-field .attributes-pair .attributes-value {

--- a/djangocms_attributes_field/widgets.py
+++ b/djangocms_attributes_field/widgets.py
@@ -100,6 +100,8 @@ class AttributesWidget(Widget):
                 border-radius: 3px;
                 display: inline-block;
                 padding: 6px 5px 8px 10px;
+                line-height: inherit;
+
             }
             .delete-attributes-pair, .add-attributes-pair {
                 line-height: 2;


### PR DESCRIPTION
Despite the fact that I am a fan of `djangocms-admin-style` some installations run without it using either the improved standard django admin (since 3.2) or third-party-packages like [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface). In these scenarios the add and remove buttons ("+" and "x") look ill-positioned and the package looks broken (despite full functionality!).

This PR changes two things:
* Keep the current markup for both buttons if djangcms-admin-style is installed.
* Let django admin style both buttons if djangocms-admin-style is not installed. Only add a `line-height` property to ensure the "+" and "x" symbols are aligned with the text.

The functionality of the package is unchanged.