### PR TITLE
fix: remove usage of ugettext_lazy from the code

### DIFF
--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -7,8 +7,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.html import conditional_escape, mark_safe
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy as _
 
 from .widgets import AttributesWidget
 
@@ -57,7 +56,7 @@ class AttributesField(models.Field):
         * The default widget is AttributesWidget from this package.
     """
     default_error_messages = {
-        'invalid': ugettext_lazy("'%s' is not a valid JSON string.")
+        'invalid': _("'%s' is not a valid JSON string.")
     }
     description = "JSON object"
 


### PR DESCRIPTION
Fixes the warning: 

```/usr/local/lib/python3.9/site-packages/djangocms_attributes_field/fields.py:60: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().```