### PR TITLE
ci: Update tests to currently supported Django and Django CMS versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, ]  # latest release minus two
+        python-version: [ 3.9, "3.10", "3.11"]  # latest release minus two
         requirements-file: [
-          dj22_cms37.txt,
-          dj22_cms38.txt,
-          dj30_cms37.txt,
-          dj30_cms38.txt,
-          dj31_cms38.txt,
+          dj32_cms311.txt,
+          dj40_cms311.txt,
+          dj41_cms311.txt,
+          dj42_cms311.txt,
         ]
         os: [
           ubuntu-20.04,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
           dj40_cms311.txt,
           dj41_cms311.txt,
           dj42_cms311.txt,
+          dj42_cms41.txt
         ]
         os: [
           ubuntu-20.04,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,16 @@
 Changelog
 =========
 
-unreleased
-==========
+3.0 (unreleaaed)
+================
+
+* Added tests for Django 4.0, 4.1, 4.2
+* Added tests for Python 3.10, 3.11
+* Dropped support for Django < 3.2
+* Dropped support for Python < 3.8
 
 2.1.0 (2022-03-27)
-==========
+==================
 
 * Fix add / delete buttons if djangocms-admin-style is not installed
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,8 @@
 django CMS Attributes Field
 ===========================
 
-|pypi| |build| |coverage|
+|pypi| |coverage|  |python| |django| |djangocms| |djangocms4|
+
 
 This project is an opinionated implementation of JSONField for arbitrary HTML
 element attributes.
@@ -22,7 +23,7 @@ provides a nice widget to provide an intuitive, key/value pair interface
 and provide sensible validation of the keys used.
 
 
-.. note:: 
+.. note::
 
     This project is considered 3rd party (no supervision by the `django CMS Association <https://www.django-cms.org/en/about-us/>`_). Join us on `Slack                 <https://www.django-cms.org/slack/>`_ for more information.
 
@@ -36,8 +37,8 @@ Contribute to this project and win rewards
 
 Because this is a an open-source project, we welcome everyone to
 `get involved in the project <https://www.django-cms.org/en/contribute/>`_ and
-`receive a reward <https://www.django-cms.org/en/bounty-program/>`_ for their contribution. 
-Become part of a fantastic community and help us make django CMS the best CMS in the world.   
+`receive a reward <https://www.django-cms.org/en/bounty-program/>`_ for their contribution.
+Become part of a fantastic community and help us make django CMS the best CMS in the world.
 
 We'll be delighted to receive your
 feedback in the form of issues and pull requests. Before submitting your
@@ -54,8 +55,6 @@ Documentation
 
 See ``REQUIREMENTS`` in the `setup.py <https://github.com/divio/djangocms-attributes-field/blob/master/setup.py>`_
 file for additional dependencies:
-
-|python| |django| |djangocms|
 
 
 Installation
@@ -166,14 +165,13 @@ You can run tests by executing::
 
 .. |pypi| image:: https://badge.fury.io/py/djangocms-attributes-field.svg
     :target: http://badge.fury.io/py/djangocms-attributes-field
-.. |build| image:: https://travis-ci.org/divio/djangocms-attributes-field.svg?branch=master
-    :target: https://travis-ci.org/divio/djangocms-attributes-field
-.. |coverage| image:: https://codecov.io/gh/divio/djangocms-attributes-field/branch/master/graph/badge.svg
+.. |coverage| image:: https://codecov.io/gh/django-cms/djangocms-attributes-field/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/divio/djangocms-attributes-field
-
-.. |python| image:: https://img.shields.io/badge/python-3.5+-blue.svg
+.. |python| image:: https://img.shields.io/badge/python-3.8+-blue.svg
     :target: https://pypi.org/project/djangocms-attributes-field/
-.. |django| image:: https://img.shields.io/badge/django-2.2,%203.0,%203.1-blue.svg
+.. |django| image:: https://img.shields.io/badge/django-3.2,%204.0--%204.2-blue.svg
     :target: https://www.djangoproject.com/
-.. |djangocms| image:: https://img.shields.io/badge/django%20CMS-3.7%2B-blue.svg
+.. |djangocms| image:: https://img.shields.io/badge/django%20CMS-3.9%2B-blue.svg
+    :target: https://www.django-cms.org/
+.. |djangocms4| image:: https://img.shields.io/badge/django%20CMS-4-blue.svg
     :target: https://www.django-cms.org/

--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -29,7 +29,7 @@ class AttributesFormField(forms.CharField):
                 return json.loads(value)
             except ValueError as exc:
                 raise forms.ValidationError(
-                    'JSON decode error: %s' % (str(exc.args[0]),)
+                    'JSON decode error: {}'.format(str(exc.args[0]))
                 )
         else:
             return value
@@ -122,7 +122,7 @@ class AttributesField(models.Field):
         """
         super().contribute_to_class(cls, name, **kwargs)
         # Make sure we're not going to clobber something that already exists.
-        property_name = '{name}_str'.format(name=name)
+        property_name = f'{name}_str'
         if not hasattr(cls, property_name):
             str_property = partial(self.to_str, field_name=name)
             setattr(cls, property_name, property(str_property))
@@ -216,7 +216,7 @@ class AttributesField(models.Field):
         for key, val in value_items:
             if key.lower() not in excluded_keys:
                 if val:
-                    attrs.append('{key}="{value}"'.format(key=key, value=conditional_escape(val)))
+                    attrs.append(f'{key}="{conditional_escape(val)}"')
                 else:
-                    attrs.append('{key}'.format(key=key))
+                    attrs.append(f'{key}')
         return mark_safe(" ".join(attrs))

--- a/djangocms_attributes_field/fields.py
+++ b/djangocms_attributes_field/fields.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from .widgets import AttributesWidget
 
 
-regex_key_validator = RegexValidator(regex=r'^[a-z][-a-z0-9_]*\Z',
+regex_key_validator = RegexValidator(regex=r'^[a-z][-a-z0-9_:]*\Z',
                                      flags=re.IGNORECASE, code='invalid')
 
 
@@ -142,7 +142,7 @@ class AttributesField(models.Field):
     def validate_key(self, key):
         """
         A key must start with a letter, but can otherwise contain letters,
-        numbers, dashes or underscores. It must not also be part of
+        numbers, dashes, colons or underscores. It must not also be part of
         `excluded_keys` as configured in the field.
 
         :param key: (str) The key to validate

--- a/djangocms_attributes_field/widgets.py
+++ b/djangocms_attributes_field/widgets.py
@@ -75,7 +75,7 @@ class AttributesWidget(Widget):
 
         # Add empty template
         output += """
-        <div class="template hidden">{0}
+        <div class="template hidden">{}
         </div>""".format(self._render_row('', '', name, flatatt(self.key_attrs), flatatt(self.val_attrs)))
 
         # Add "+" button
@@ -194,8 +194,8 @@ class AttributesWidget(Widget):
         :param files: (list) request.FILES
         :param name: (str) the name of the field associated with this widget.
         """
-        key_field = 'attributes_key[{0}]'.format(name)
-        val_field = 'attributes_value[{0}]'.format(name)
+        key_field = f'attributes_key[{name}]'
+        val_field = f'attributes_value[{name}]'
         if key_field in data and val_field in data:
             keys = data.getlist(key_field)
             values = data.getlist(val_field)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from djangocms_attributes_field import __version__
 
 REQUIREMENTS = [
     'django-cms>=3.7',
-    'django-treebeard>=4.3,<4.5',
 ]
 
 
@@ -18,17 +17,20 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Framework :: Django',
-    'Framework :: Django :: 2.2',
-    'Framework :: Django :: 3.0',
-    'Framework :: Django :: 3.1',
+    'Framework :: Django :: 3.2',
+    'Framework :: Django :: 4.0',
+    'Framework :: Django :: 4.1',
+    'Framework :: Django :: 4.2',
     'Framework :: Django CMS',
-    'Framework :: Django CMS :: 3.7',
-    'Framework :: Django CMS :: 3.8',
+    'Framework :: Django CMS :: 3.9',
+    'Framework :: Django CMS :: 3.10',
+    'Framework :: Django CMS :: 3.11',
+    'Framework :: Django CMS :: 4.1',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Software Development',

--- a/tests/requirements/dj22_cms37.txt
+++ b/tests/requirements/dj22_cms37.txt
@@ -1,4 +1,0 @@
--r base.txt
-
-Django>=2.2,<3.0
-django-cms>=3.7,<3.8

--- a/tests/requirements/dj22_cms38.txt
+++ b/tests/requirements/dj22_cms38.txt
@@ -1,4 +1,0 @@
--r base.txt
-
-Django>=2.2,<3.0
-django-cms>=3.8,<3.9

--- a/tests/requirements/dj30_cms37.txt
+++ b/tests/requirements/dj30_cms37.txt
@@ -1,4 +1,0 @@
--r base.txt
-
-Django>=3.0,<3.1
-django-cms>=3.7,<3.8

--- a/tests/requirements/dj30_cms38.txt
+++ b/tests/requirements/dj30_cms38.txt
@@ -1,4 +1,0 @@
--r base.txt
-
-Django>=3.0,<3.1
-django-cms>=3.8,<3.9

--- a/tests/requirements/dj31_cms38.txt
+++ b/tests/requirements/dj31_cms38.txt
@@ -1,4 +1,0 @@
--r base.txt
-
-Django>=3.1,<3.2
-django-cms>=3.8,<3.9

--- a/tests/requirements/dj32_cms310.txt
+++ b/tests/requirements/dj32_cms310.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=3.2,<4.0
+django-cms>=3.10,<3.11

--- a/tests/requirements/dj32_cms311.txt
+++ b/tests/requirements/dj32_cms311.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=3.2,<4
+django-cms>=3.11,<4

--- a/tests/requirements/dj32_cms39.txt
+++ b/tests/requirements/dj32_cms39.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=3.2,<4.0
+django-cms>=3.9,<3.10

--- a/tests/requirements/dj40_cms311.txt
+++ b/tests/requirements/dj40_cms311.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=4.0,<4.1
+django-cms>=3.11.1,<4

--- a/tests/requirements/dj41_cms311.txt
+++ b/tests/requirements/dj41_cms311.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=4.1,<4.2
+django-cms>=3.11.1,<4

--- a/tests/requirements/dj42_cms311.txt
+++ b/tests/requirements/dj42_cms311.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=4.2,<5.0
+django-cms>=3.11.2,<4

--- a/tests/requirements/dj42_cms41.txt
+++ b/tests/requirements/dj42_cms41.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=4.1,<5.0
+django-cms==4.1rc1

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,6 +12,7 @@ HELPER_SETTINGS = {
     },
     'LANGUAGE_CODE': 'en',
     'ALLOWED_HOSTS': ['localhost'],
+    'CMS_CONFIRM_VERSION4': True,
 }
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -25,6 +25,7 @@ class KeyValidationTests(TestCase):
             field.validate_key('a-1')
             field.validate_key('a_1')
             field.validate_key('a-A1_')
+            field.validate_key('v-on:click')
         except ValidationError:
             self.fail('Keys that pass have failed.')
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -19,7 +19,7 @@ class MigrationTestCase(TestCase):
         }
 
         try:
-            call_command('makemigrations', **options)
+            call_command('makemigrations', 'djangocms_attributes_field', **options)
         except SystemExit as e:
             status_code = str(e)
         else:


### PR DESCRIPTION
## Description

This PR updates the test runs to work with django CMS 4 and Django up to 4.2. If also removes the requirement on indirect dependency `django-treebeard`.

Finally, it formally allows colons (`:`) as part of attribute names for applications like, e.g., vue.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #51 
* #52

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
